### PR TITLE
Tests added

### DIFF
--- a/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
+++ b/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
@@ -23,7 +23,7 @@ class ServiceRoutesSpec extends CatsEffectSuite:
   private val success: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(Some(User(123, None)))
     override def insertUser(user: User): IO[User] = ???
-    override def deleteUserById(userId: Long): IO[Unit] = ???
+    override def deleteUserById(userId: Long): IO[Unit] = IO.pure(Some(User(123, None)))
 
   private val foundNone: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(None)
@@ -67,3 +67,9 @@ class ServiceRoutesSpec extends CatsEffectSuite:
     }
 
     assert(result == Right("Should not get called!"))
+
+  test("DELETE api/v1/users/123 should return 200 OK with correct response if user exists and was deleted"):
+    val request: Request[IO] = Request(method = Method.DELETE, uri = uri"/api/v1/users/123")
+    val client = Client.fromHttpApp(userServiceRoutes(success))
+    val status = client.status(request)
+    assertIO(status, Ok)

--- a/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
+++ b/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
@@ -82,7 +82,7 @@ class ServiceRoutesSpec extends CatsEffectSuite:
     assertIO(status, Ok)
 
   test("DELETE api/v1/users/123 should return 500 when an exception is thrown"):
-    val request: Request[IO] = Request(method = Method.GET, uri = uri"/api/v1/users/123")
+    val request: Request[IO] = Request(method = Method.DELETE, uri = uri"/api/v1/users/123")
 
     val result = try {
       val client = Client.fromHttpApp(userServiceRoutes(exception))

--- a/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
+++ b/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
@@ -23,17 +23,17 @@ class ServiceRoutesSpec extends CatsEffectSuite:
   private val success: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(Some(User(123, None)))
     override def insertUser(user: User): IO[User] = ???
-    override def deleteUserById(userId: Long): IO[Unit] = IO.pure(Some(User(123, None)))
+    override def deleteUserById(userId: Long): IO[Unit] = IO { println(s"Deleting user: $userId") }
 
   private val foundNone: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(None)
     override def insertUser(user: User): IO[User] = ???
-    override def deleteUserById(userId: Long): IO[Unit] = ???
+    override def deleteUserById(userId: Long): IO[Unit] = IO { println(s"User $userId not found") }
 
   private val exception: UserRepo[IO] = new UserRepo[IO]:
-    override def getUserById(id: Long): IO[Option[User]] = IO.raiseError(new RuntimeException("Should not get called!"))
+    override def getUserById(id: Long): IO[Option[User]] = IO.raiseError(new RuntimeException("Exception thrown!"))
     override def insertUser(user: User): IO[User] = ???
-    override def deleteUserById(userId: Long): IO[Unit] = ???
+    override def deleteUserById(userId: Long): IO[Unit] = IO.raiseError(new RuntimeException("Exception thrown!"))
 
   private def userServiceRoutes(repo: UserRepo[IO]) =
     ServiceRoutes.userRoutes[IO](new UserServiceImpl[IO](repo)).orNotFound
@@ -66,10 +66,32 @@ class ServiceRoutesSpec extends CatsEffectSuite:
       case _: Throwable => Left("Unexpected exception")
     }
 
-    assert(result == Right("Should not get called!"))
+    assert(result == Right("Exception thrown!"))
 
-  test("DELETE api/v1/users/123 should return 200 OK with correct response if user exists and was deleted"):
+  test("DELETE api/v1/users/123 should return 200 OK if user is found and deleted. Logs that user was deleted"):
     val request: Request[IO] = Request(method = Method.DELETE, uri = uri"/api/v1/users/123")
     val client = Client.fromHttpApp(userServiceRoutes(success))
     val status = client.status(request)
     assertIO(status, Ok)
+
+  // Is this right? Or should it be 404? Is there a way to get 404 error when return type is IO[Unit] or is this not possible?
+  test("DELETE api/v1/users/123 should return 200 if user is not found and nothing deleted. Logs that nothing was deleted"):
+    val request: Request[IO] = Request(method = Method.DELETE, uri = uri"/api/v1/users/123")
+    val client = Client.fromHttpApp(userServiceRoutes(foundNone))
+    val status = client.status(request)
+    assertIO(status, Ok)
+
+  test("DELETE api/v1/users/123 should return 500 when an exception is thrown"):
+    val request: Request[IO] = Request(method = Method.GET, uri = uri"/api/v1/users/123")
+
+    val result = try {
+      val client = Client.fromHttpApp(userServiceRoutes(exception))
+      val status = client.status(request)
+      status.unsafeRunSync()
+      Left("No exception thrown")
+    } catch {
+      case e: RuntimeException => Right(e.getMessage)
+      case _: Throwable => Left("Unexpected exception")
+    }
+
+    assert(result == Right("Exception thrown!"))

--- a/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
+++ b/src/test/scala/com/strad/service/ServiceRoutesSpec.scala
@@ -15,24 +15,27 @@ import munit.CatsEffectSuite
 import org.http4s.*
 import org.http4s.circe.*
 import org.http4s.circe.CirceEntityDecoder.circeEntityDecoder
+import org.http4s.circe.CirceEntityEncoder.circeEntityEncoder
 import org.http4s.client.Client
 import org.http4s.dsl.io.*
 import org.http4s.implicits.uri
+import com.strad.service.domain.{UserRequest, UserResponse}
 
 class ServiceRoutesSpec extends CatsEffectSuite:
   private val success: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(Some(User(123, None)))
-    override def insertUser(user: User): IO[User] = ???
+    override def insertUser(user: User): IO[User] = IO.pure(User(123, Some("new-email@email.com")))
     override def deleteUserById(userId: Long): IO[Unit] = IO { println(s"Deleting user: $userId") }
 
   private val foundNone: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.pure(None)
+    // I don't think it makes sense to have a test case for 'foundNone' when inserting a user
     override def insertUser(user: User): IO[User] = ???
     override def deleteUserById(userId: Long): IO[Unit] = IO { println(s"User $userId not found") }
 
   private val exception: UserRepo[IO] = new UserRepo[IO]:
     override def getUserById(id: Long): IO[Option[User]] = IO.raiseError(new RuntimeException("Exception thrown!"))
-    override def insertUser(user: User): IO[User] = ???
+    override def insertUser(user: User): IO[User] = IO.raiseError(new RuntimeException("Exception thrown!"))
     override def deleteUserById(userId: Long): IO[Unit] = IO.raiseError(new RuntimeException("Exception thrown!"))
 
   private def userServiceRoutes(repo: UserRepo[IO]) =
@@ -95,3 +98,27 @@ class ServiceRoutesSpec extends CatsEffectSuite:
     }
 
     assert(result == Right("Exception thrown!"))
+
+  test("POST api/v1/users/ should return 200 OK if user is inserted properly"):
+    val request: Request[IO] = Request(method = Method.POST, uri = uri"/api/v1/users").withEntity(UserRequest(Some("new-email@email.com")))
+    val client = Client.fromHttpApp(userServiceRoutes(success))
+    val status = client.status(request)
+    assertIO(status, Ok)
+
+    // Is this sufficient or should we check that the right user is returned too?
+
+  test("POST api/v1/users/ should return 500 when an exception is thrown"):
+    val request: Request[IO] = Request(method = Method.POST, uri = uri"/api/v1/users").withEntity(UserRequest(Some("new-email@email.com")))
+    val result = try {
+      val client = Client.fromHttpApp(userServiceRoutes(exception))
+      val status = client.status(request)
+      // still don't know if using unsafeRunSync inside a test would be the best approach or not...
+      status.unsafeRunSync()
+      Left("No exception thrown")
+    } catch {
+      case e: RuntimeException => Right(e.getMessage)
+      case _: Throwable => Left("Unexpected exception")
+    }
+
+    assert(result == Right("Exception thrown!"))
+    


### PR DESCRIPTION
Would this be the proper way to test a 'success' case for the DELETE route?  If so, I'll add on to the rest of the test cases in a similar format. If not, let me know what is wrong here.

Also, is there a way to group these tests together in a better way? If this is the right approach...it seems like many 'success' cases for different routes would share a lot of the same code (i.e. the 'success' for deleting a user, inserting a user, and getting user by ID all return 200 Ok after making request)...is there a better practice to share code across tests?

Thanks!